### PR TITLE
Proposed modification to xsd to clarify use of Count objects

### DIFF
--- a/NIST_V2_election_results_reporting.xsd
+++ b/NIST_V2_election_results_reporting.xsd
@@ -212,6 +212,17 @@
       </xsd:extension>
     </xsd:simpleContent>
   </xsd:complexType>
+  <xsd:complexType name="BallotCounts">
+    <xsd:complexContent>
+      <xsd:extension base="Counts">
+        <xsd:sequence>
+          <xsd:element name="BallotsCast" type="xsd:integer" minOccurs="0"/>
+          <xsd:element name="BallotsOutstanding" type="xsd:integer" minOccurs="0"/>
+          <xsd:element name="BallotsRejected" type="xsd:integer" minOccurs="0"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
   <xsd:complexType name="BallotMeasureContest">
     <xsd:complexContent>
       <xsd:extension base="Contest">
@@ -330,7 +341,7 @@
       <xsd:element name="Name" type="xsd:string"/>
       <xsd:element name="SequenceOrder" type="xsd:integer" minOccurs="0"/>
       <xsd:element name="SubUnitsReported" type="xsd:integer" minOccurs="0"/>
-      <xsd:element name="SummaryCounts" type="SummaryCounts" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="ErrorCounts" type="ErrorCounts" minOccurs="0" maxOccurs="unbounded"/>
       <xsd:element name="TotalSubUnits" type="xsd:integer" minOccurs="0"/>
       <xsd:element name="VoteVariation" type="VoteVariation" minOccurs="0"/>
       <xsd:element name="OtherVoteVariation" type="xsd:string" minOccurs="0"/>
@@ -347,7 +358,7 @@
   <xsd:complexType name="Counts" abstract="true">
     <xsd:sequence>
       <xsd:element name="Device" type="Device" minOccurs="0"/>
-      <xsd:element name="GpUnitId" type="xsd:IDREF" minOccurs="0"/>
+      <xsd:element name="GpUnitId" type="xsd:IDREF"/>
       <xsd:element name="IsSuppressedForPrivacy" type="xsd:boolean" minOccurs="0"/>
       <xsd:element name="Type" type="CountItemType"/>
       <xsd:element name="OtherType" type="xsd:string" minOccurs="0"/>
@@ -363,6 +374,7 @@
   </xsd:complexType>
   <xsd:complexType name="Election">
     <xsd:sequence>
+      <xsd:element name="BallotCounts" type="BallotCounts" minOccurs="0" maxOccurs="unbounded"/>
       <xsd:element name="BallotStyle" type="BallotStyle" minOccurs="0" maxOccurs="unbounded"/>
       <xsd:element name="Candidate" type="Candidate" minOccurs="0" maxOccurs="unbounded"/>
       <xsd:element name="ContactInformation" type="ContactInformation" minOccurs="0"/>
@@ -407,6 +419,17 @@
       <xsd:element name="VendorApplicationId" type="xsd:string"/>
     </xsd:sequence>
   </xsd:complexType>
+  <xsd:complexType name="ErrorCounts">
+    <xsd:complexContent>
+      <xsd:extension base="Counts">
+        <xsd:sequence>
+          <xsd:element name="Overvotes" type="xsd:integer" minOccurs="0"/>
+          <xsd:element name="Undervotes" type="xsd:integer" minOccurs="0"/>
+          <xsd:element name="WriteIns" type="xsd:integer" minOccurs="0"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
   <xsd:complexType name="ExternalIdentifier">
     <xsd:sequence>
       <xsd:element name="Type" type="IdentifierType"/>
@@ -420,7 +443,6 @@
       <xsd:element name="ComposingGpUnitIds" type="xsd:IDREFS" minOccurs="0"/>
       <xsd:element name="ExternalIdentifier" type="ExternalIdentifier" minOccurs="0" maxOccurs="unbounded"/>
       <xsd:element name="Name" type="xsd:string" minOccurs="0"/>
-      <xsd:element name="SummaryCounts" type="SummaryCounts" minOccurs="0" maxOccurs="unbounded"/>
     </xsd:sequence>
     <xsd:attribute name="ObjectId" type="xsd:ID" use="required"/>
   </xsd:complexType>
@@ -598,20 +620,6 @@
       <xsd:element name="Coordinates" type="xsd:string"/>
       <xsd:element name="Format" type="GeoSpatialFormat"/>
     </xsd:sequence>
-  </xsd:complexType>
-  <xsd:complexType name="SummaryCounts">
-    <xsd:complexContent>
-      <xsd:extension base="Counts">
-        <xsd:sequence>
-          <xsd:element name="BallotsCast" type="xsd:integer" minOccurs="0"/>
-          <xsd:element name="BallotsOutstanding" type="xsd:integer" minOccurs="0"/>
-          <xsd:element name="BallotsRejected" type="xsd:integer" minOccurs="0"/>
-          <xsd:element name="Overvotes" type="xsd:integer" minOccurs="0"/>
-          <xsd:element name="Undervotes" type="xsd:integer" minOccurs="0"/>
-          <xsd:element name="WriteIns" type="xsd:integer" minOccurs="0"/>
-        </xsd:sequence>
-      </xsd:extension>
-    </xsd:complexContent>
   </xsd:complexType>
   <xsd:complexType name="Term">
     <xsd:sequence>


### PR DESCRIPTION
This PR proposes some changes to simplify the use of the Counts objects.   The change is directly to the XSD, so is only meant to make the proposal easily understandable.

We propose the following:

1. Splitting out "SummaryCounts" into "ErrorCounts" and "BallotCounts".
2. "Election" will add a new reference to "BallotCounts", "Contest" will replace its reference to "SummaryCounts" with "ErrorCounts", "GpUnit" will remove its reference to "SummaryCounts"
3. "GpUnitId" will be made required for the "Counts" object.

There are two items in particular which still need some discussion:
1. "ErrorCounts" should be renamed to something more accurate, as "Undervotes" in most elections won't be considered an error.
2. Should "WriteIn" be removed from "ErrorCounts"? It is already a valid "CountItemType" for the parent "Counts" object.